### PR TITLE
Added logic to skip encryption for dynamic email recipients

### DIFF
--- a/src/Extensions/UserDefinedFormControllerExtension.php
+++ b/src/Extensions/UserDefinedFormControllerExtension.php
@@ -15,21 +15,18 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\SMIME\Control\SMIMEMailer;
 use SilverStripe\SmimeForms\Model\SmimeEncryptionCertificate;
 use SilverStripe\SmimeForms\Model\SmimeSigningCertificate;
-use SilverStripe\UserForms\Control\UserDefinedFormController;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 
 /**
  * Class UserDefinedFormControllerExtension
  *
- * An extension for {@see UserDefinedForm} class to check whether the form submission needs
+ * An extension for {@see UserDefinedFormController} class to check whether the form submission needs
  * to be encrypted. If so, it will replace the standard Mailer with a {@see SMIMEMailer}.
  *
  * @package SilverStripe\SmimeForms\Extensions
  */
 class UserDefinedFormControllerExtension extends DataExtension
 {
-
-    private $defaultMailer = null;
 
     /**
      * Called as an extension hook from {@see UserDefinedFormController}.
@@ -66,7 +63,6 @@ class UserDefinedFormControllerExtension extends DataExtension
 
                 $email->setSubject(sprintf('%s %s', $subject, $encryptionMessage));
             }
-
 
             $senderEmailAddress = array_key_first($email->getFrom());
 

--- a/src/Extensions/UserDefinedFormControllerExtension.php
+++ b/src/Extensions/UserDefinedFormControllerExtension.php
@@ -15,6 +15,7 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\SMIME\Control\SMIMEMailer;
 use SilverStripe\SmimeForms\Model\SmimeEncryptionCertificate;
 use SilverStripe\SmimeForms\Model\SmimeSigningCertificate;
+use SilverStripe\UserForms\Control\UserDefinedFormController;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 
 /**
@@ -28,8 +29,10 @@ use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 class UserDefinedFormControllerExtension extends DataExtension
 {
 
+    private $defaultMailer = null;
+
     /**
-     * Called as an extension hook from {@see UserDefinedForm}.
+     * Called as an extension hook from {@see UserDefinedFormController}.
      *
      * @throws NotFoundExceptionInterface
      * @throws Exception
@@ -41,28 +44,36 @@ class UserDefinedFormControllerExtension extends DataExtension
             return;
         }
 
+        // If the To field is a dynamic field then allow email to be sent without encryption or warning
+        $skipEncryption = $recipient->SendEmailToField()->exists();
+
         $pathToFile = null;
+        $signingCredentials = [];
 
-        // Check for a recipient encryption certificate, with a matching email address, and set path to file
-        $encryptionCertificateEntry = SmimeEncryptionCertificate::get()
-            ->filter('EmailAddress', $recipient->EmailAddress)->first();
+        if (!$skipEncryption) {
+            // Check for a recipient encryption certificate, with a matching email address, and set path to file
+            $encryptionCertificateEntry = SmimeEncryptionCertificate::get()
+                ->filter('EmailAddress', $recipient->EmailAddress)->first();
 
-        if ($encryptionCertificateEntry && $encryptionCertificateEntry->EncryptionCrt->exists()) {
-            $pathToFile = $this->getFilePath($encryptionCertificateEntry->EncryptionCrt);
+            if ($encryptionCertificateEntry && $encryptionCertificateEntry->EncryptionCrt->exists()) {
+                $pathToFile = $this->getFilePath($encryptionCertificateEntry->EncryptionCrt);
+            }
+
+            // If no encryption certificate was found then proceed but append a warning to the email.
+            if (!$pathToFile) {
+                $subject = $email->getSubject();
+                $encryptionMessage = '[UNENCRYPTED: CHECK CMS CONFIGURATION]';
+
+                $email->setSubject(sprintf('%s %s', $subject, $encryptionMessage));
+            }
+
+
+            $senderEmailAddress = array_key_first($email->getFrom());
+
+            $signingCredentials = $this->checkForSigningCredentials($senderEmailAddress);
         }
 
-        // If no encryption certificate was found then proceed but append a warning to the email.
-        if (!$pathToFile) {
-            $subject = $email->getSubject();
-            $encryptionMessage = '[UNENCRYPTED: CHECK CMS CONFIGURATION]';
-
-            $email->setSubject(sprintf('%s %s', $subject, $encryptionMessage));
-        }
-
-        $senderEmailAddress = array_key_first($email->getFrom());
-
-        $signingCredentials = $this->checkForSigningCredentials($senderEmailAddress);
-
+        // Re-registering SmimeMailer for each recipient with appropriate encryption/signing details
         $this->registerSMIMEMailer(
             $pathToFile,
             $signingCredentials

--- a/tests/UserDefinedFormControllerExtensionTest.php
+++ b/tests/UserDefinedFormControllerExtensionTest.php
@@ -12,6 +12,7 @@ use SilverStripe\SmimeForms\Extensions\UserDefinedFormControllerExtension;
 use SilverStripe\SmimeForms\Model\SmimeEncryptionCertificate;
 use SilverStripe\SmimeForms\Model\SmimeSigningCertificate;
 use SilverStripe\UserForms\Control\UserDefinedFormController;
+use SilverStripe\UserForms\Model\EditableFormField\EditableEmailField;
 use SilverStripe\UserForms\Model\Recipient\EmailRecipient;
 
 class UserDefinedFormControllerExtensionTest extends SapphireTest
@@ -209,6 +210,89 @@ class UserDefinedFormControllerExtensionTest extends SapphireTest
             );
 
         $controller->updateEmail($email, $recipient);
+    }
+
+    public function testUpdateEmailSubjectWhenEmailWithoutEncryptionCertificate(): void
+    {
+        // Get the form and set encryption to true
+        $form = $this->objFromFixture(ElementForm::class, 'registration_form');
+        $form->UseEncryption = true;
+
+        $emailField = $this->objFromFixture(EditableEmailField::class, 'email-field1');
+
+        $email = Email::create();
+        $email->setFrom('sender@example.com');
+        $email->setSubject('Registration Form');
+
+        $recipient = EmailRecipient::create();
+        $recipient->EmailAddress = 'other-recipient@example.com';
+        $recipient->EmailFrom = 'sender@example.com';
+        $recipient->write();
+
+        $controller = UserDefinedFormController::create($form);
+        $controller->updateEmail($email, $recipient);
+
+        // An email recipient without encryption certificate will have updated subject
+        $this->assertEquals('Registration Form [UNENCRYPTED: CHECK CMS CONFIGURATION]', $email->getSubject());
+
+    }
+
+    /**
+     * When recipients of forms are dynamic (from an input field) then
+     * encryption should be skipped.
+     */
+    public function testUpdateEmailWithDynamicRecipient(): void
+    {
+        // Get the form and set encryption to true
+        $form = $this->objFromFixture(ElementForm::class, 'registration_form');
+        $form->UseEncryption = true;
+
+        $emailField = $this->objFromFixture(EditableEmailField::class, 'email-field1');
+
+        // Set up email and dynamic recipient (email taken from email field in form)
+        $recipient = EmailRecipient::create();
+        $recipient->EmailAddress = 'dynamic-recipient@example.com';
+        $recipient->SendEmailToFieldID = $emailField->ID;
+        $recipient->EmailFrom = 'sender@example.com';
+        $recipient->write();
+
+        $email = Email::create();
+        $email->setFrom('sender@example.com');
+        $email->setSubject('Registration Form');
+
+        // Mock the extension we are testing and inject it
+        $mockedExtension = $this->getMockBuilder(UserDefinedFormControllerExtension::class)
+            ->onlyMethods(['registerSMIMEMailer'])
+            ->getMock();
+
+        Injector::inst()->registerService($mockedExtension, UserDefinedFormControllerExtension::class);
+
+        // Instantiate the controller which will pick up our mocked extension
+        $controller = UserDefinedFormController::create($form);
+
+        // Set up expectations for calling the mocked registerSMIMEMailer function
+        // to check file paths and expected signing credentials.
+        // Since we can't check on the full system path a callback is used for each argument so
+        // that we can make partial assertions.
+        $mockedExtension
+            ->expects($this->once())
+            ->method('registerSMIMEMailer')
+            ->with(
+                $this->callback(function ($encryptionFilePath) {
+                    $this->assertNull($encryptionFilePath);
+
+                    return true;
+                }),
+                $this->callback(function ($signingCertificate) {
+                    $this->assertEquals([], $signingCertificate);
+
+                    return true;
+                })
+            );
+
+        $controller->updateEmail($email, $recipient);
+
+        $this->assertEquals('Registration Form', $email->getSubject()); // No warning and no encryption
     }
 
 }

--- a/tests/UserDefinedFormControllerExtensionTest.php
+++ b/tests/UserDefinedFormControllerExtensionTest.php
@@ -212,6 +212,10 @@ class UserDefinedFormControllerExtensionTest extends SapphireTest
         $controller->updateEmail($email, $recipient);
     }
 
+    /**
+     * When email recipients are missing an encryption certificate the subject
+     * is appended with a warning to configure CMS.
+     */
     public function testUpdateEmailSubjectWhenEmailWithoutEncryptionCertificate(): void
     {
         // Get the form and set encryption to true

--- a/tests/UserDefinedFormControllerExtensionTest.php
+++ b/tests/UserDefinedFormControllerExtensionTest.php
@@ -222,8 +222,6 @@ class UserDefinedFormControllerExtensionTest extends SapphireTest
         $form = $this->objFromFixture(ElementForm::class, 'registration_form');
         $form->UseEncryption = true;
 
-        $emailField = $this->objFromFixture(EditableEmailField::class, 'email-field1');
-
         $email = Email::create();
         $email->setFrom('sender@example.com');
         $email->setSubject('Registration Form');
@@ -238,7 +236,6 @@ class UserDefinedFormControllerExtensionTest extends SapphireTest
 
         // An email recipient without encryption certificate will have updated subject
         $this->assertEquals('Registration Form [UNENCRYPTED: CHECK CMS CONFIGURATION]', $email->getSubject());
-
     }
 
     /**

--- a/tests/UserDefinedFormControllerExtensionTest.yml
+++ b/tests/UserDefinedFormControllerExtensionTest.yml
@@ -16,6 +16,14 @@ SilverStripe\UserForms\Model\EditableFormField\EditableTextField:
     Title: Custom field
     Placeholder: Custom field
 
+SilverStripe\UserForms\Model\EditableFormField\EditableEmailField:
+  email-field1:
+    Name: Email
+    Sort: 13
+    Parent: =>DNADesign\ElementalUserForms\Model\ElementForm.registration_form
+    Title: Email
+    Placeholder: Enter your email
+
 Page:
   RegistrationForm:
     Title: "Registration Form"


### PR DESCRIPTION
# Description

User forms can be configured with dynamic email recipients. That is, the recipient can be set up to come from an email field from the submitted form.

In this scenario an encryption certificate will not be available and it doesn't make sense to include [UNENCRYPTED: CHECK CMS CONFIGURATION] within the email subject.  This enhancement is to skip adding this message to the subject if the recipient email comes from a form field.

